### PR TITLE
add a missing translation in before-after

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -10,6 +10,7 @@ de:
         leave_view: Vorher/Nachher-Ansicht verlassen
         start: Vorher/Nachher-Ansicht starten
         start_title: Vorher/Nachher-Ansicht starten
+        drag_hint: Linke Maustaste drücken und nach links oder rechts ziehen
       chapter: Kapitel
       chart:
         toggle: Ansicht vergrößern bzw. verkleinern

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10,6 +10,7 @@ en:
         leave_view: Leave before/after view
         start: Start before/after view
         start_title: Start before/after view
+        drag_hint: Press the left mouse button and move left or right
       chapter: Chapter
       chart:
         toggle: Toggle

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -10,6 +10,7 @@ nl:
         leave_view: Verlaat de voor/na weergave
         start: Start de voor/na weergave
         start_title: Start de voor/na weergave
+        drag_hint: Linkermuisknop indrukken en naar links of rechts bewegen
       chapter: Hoofdstuk
       chart:
         toggle: In-/uitschakelen


### PR DESCRIPTION
As discussed in https://github.com/codevise/pageflow-before-after/issues/17 this pull request adds a missing drag wrapper title in `pageflow-before-after`.